### PR TITLE
Add UTF-8 characters encoding

### DIFF
--- a/_controller.py
+++ b/_controller.py
@@ -41,7 +41,7 @@ class Quinn:
             message (str): The log message to write.
             filename (str, optional): The name of the file to write to. Defaults to "./logs/logs.txt".
         """
-        with open(filename, "a") as file:
+        with open(filename, "a", encoding='UTF-8') as file:
             file.write(f"{message}\n")
 
     def click_on(self, element_name, element_selector):


### PR DESCRIPTION
Add UTF-8 characters encoding when opening a file so that we can use emojis and other characters in the log files.

closes #1